### PR TITLE
match changes to mapbox-gl

### DIFF
--- a/src/Camera/CameraSync.js
+++ b/src/Camera/CameraSync.js
@@ -77,7 +77,7 @@ CameraSync.prototype = {
             .makeTranslation(ThreeboxConstants.WORLD_SIZE/2, -ThreeboxConstants.WORLD_SIZE / 2, 0);
         
         translateMap
-            .makeTranslation(-this.map.transform.x, this.map.transform.y , 0);
+            .makeTranslation(-this.map.transform.point.x, this.map.transform.point.y , 0);
         
         rotateMap
             .makeRotationZ(Math.PI);

--- a/src/Camera/CameraSync.js
+++ b/src/Camera/CameraSync.js
@@ -76,8 +76,10 @@ CameraSync.prototype = {
         translateCenter
             .makeTranslation(ThreeboxConstants.WORLD_SIZE/2, -ThreeboxConstants.WORLD_SIZE / 2, 0);
         
+        var x = this.map.transform.x || this.map.transform.point.x;
+        var y = this.map.transform.y || this.map.transform.point.y;
         translateMap
-            .makeTranslation(-this.map.transform.point.x, this.map.transform.point.y , 0);
+            .makeTranslation(-x, y , 0);
         
         rotateMap
             .makeRotationZ(Math.PI);


### PR DESCRIPTION
The mapbox-gl Transform class changed in October (Merge #7488) making transform.x / transform.y properties of transform.point

fixing issue #46 