### PR TITLE
minor changes to get Threebox to work and build in angular.

### DIFF
--- a/src/Animation/AnimationManager.js
+++ b/src/Animation/AnimationManager.js
@@ -1,4 +1,4 @@
-var threebox = require('../Threebox.js');
+var threebox = require('../threebox.js');
 var utils = require("../utils/utils.js");
 var validate = require("../utils/validate.js");
 

--- a/src/objects/objects.js
+++ b/src/objects/objects.js
@@ -1,5 +1,6 @@
 var utils = require("../utils/utils.js");
 var material = require("../utils/material.js");
+var THREE = require("../three.js");
 
 const AnimationManager = require("../animation/AnimationManager.js");
 
@@ -41,11 +42,11 @@ Objects.prototype = {
 
 	},
 
-	_addMethods: function(obj, static){
+	_addMethods: function(obj, fixed){
 
 		var root = this;
 
-		if (static) {
+		if (fixed) {
 
 		}
 
@@ -93,7 +94,7 @@ Objects.prototype = {
 
 		obj.add = function(){
 	        root.world.add(obj);
-	        if (!static) obj.set({position:obj.coordinates});
+	        if (!fixed) obj.set({position:obj.coordinates});
 	        return obj;
 		}
 

--- a/src/utils/material.js
+++ b/src/utils/material.js
@@ -5,7 +5,7 @@
 // - specify a `material` string, `color`, and/or `opacity` as modifications of the default material
 // - provide none of these parameters, to use the default material
 
-var utils = require("../Utils/Utils.js");
+var utils = require("./utils.js");
 var THREE = require("../three.js");
 
 var defaults = {


### PR DESCRIPTION
When using the threebox npm package in angular, you get:

1. There was a three.js file import missing and that was added.
2. Warnings regarding filename casings. I refactored the casings accordingly so when you run `ng-serve` it serves warning-free.
3. When you run `ng-build --prod`, you are with an error from terser saying that there is a `missing token name ( static )` which is one of the variable names in the object.js file. I renamed this variable to `fixed`.